### PR TITLE
add autoindexing in vhosts locations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,3 +131,13 @@ nginx_vhosts: []
 #         - location: /cgi-bin/icinga
 #           root: /usr/lib/cgi-bin/icinga
 #           document_root: /usr/lib
+#     # this example shows how to configure nginx with autoindex for listing a directory
+#     - name: mirror.example.com
+#       default: true
+#       type: standard-with-http
+#       acme: false
+#       document_root: /var/lib/mirror
+#       alias:
+#         - src: /
+#           dest: /var/lib/mirror/
+#           autoindex: true

--- a/templates/etc/nginx/vhosts.d/standard-with-http.j2
+++ b/templates/etc/nginx/vhosts.d/standard-with-http.j2
@@ -57,6 +57,9 @@ server {
 
     location {{ alias.src }} {
         alias {{ alias.dest }};
+        {% if alias.autoindex %}
+        autoindex on;
+        {% endif %}
     }
 {% endfor %}
 {% endif %}
@@ -108,6 +111,9 @@ server {
 
     location {{ alias.src }} {
         alias {{ alias.dest }};
+        {% if alias.autoindex %}
+        autoindex on;
+        {% endif %}
     }
 {% endfor %}
 {% endif %}

--- a/templates/etc/nginx/vhosts.d/standard.j2
+++ b/templates/etc/nginx/vhosts.d/standard.j2
@@ -57,6 +57,9 @@ server {
 
     location {{ alias.src }} {
         alias {{ alias.dest }};
+        {% if alias.autoindex %}
+        autoindex on;
+        {% endif %}
     }
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

When listing a directory one needs to add autoindex on in the nginx configuration.

http://nginx.org/en/docs/http/ngx_http_autoindex_module.html