### PR TITLE
install apt-transport-https before configuring upstream repo

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: ensure apt-transport-https is installed
+  apt:
+    name: apt-transport-https
+    state: present
+  when: ansible_os_family == 'Debian'
+
 - name: configure upstream nginx apt key
   apt_key:
     url: '{{ nginx_upstream_repo_key }}'


### PR DESCRIPTION
##### SUMMARY
Prevent error:
E:The method driver /usr/lib/apt/methods/https could not be found.
