### PR TITLE
support oracle linux by adding nginx rhel repos

### DIFF
--- a/templates/etc/yum.repos.d/nginx.repo.j2
+++ b/templates/etc/yum.repos.d/nginx.repo.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-{% if ansible_distribution == "RedHat" %}
+{% if ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux" %}
 {% set distribution = "rhel" %}
 {% else %}
 {% set distribution = ansible_distribution %}


### PR DESCRIPTION
##### SUMMARY
Support Oracle Linux by adding the official rhel repos of nginx.

see: http://johanlouwers.blogspot.com/2016/01/install-nginx-on-oracle-linux.html

##### ISSUE TYPE
This role can't be used on Oracle Linux (Repos doesn't exist for OL)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.30
```
